### PR TITLE
Fix icons

### DIFF
--- a/shiki-light-theme.css
+++ b/shiki-light-theme.css
@@ -977,8 +977,8 @@ select{
 }
 .b-feedback > .marker-positioner::after {
     position: absolute;
-    font-family: 'Material Icons';
-    content: 'error_outline';
+    font-family: 'Material Icons Outlined';
+    content: 'report';
     font-size: 30px;
     padding: 5px;
     top: 0;

--- a/shiki-light-theme.css
+++ b/shiki-light-theme.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
+
 @font-face {
   font-family: 'FontAwesome';
   src: url('//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/fonts/fontawesome-webfont.eot?v=4.7.0');
@@ -9,7 +11,6 @@
   font-weight: normal;
   font-style: normal;
 }
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
 
 /* sticky_menu */
 @media screen and (min-width: 1025px) {
@@ -977,8 +978,8 @@ select{
 }
 .b-feedback > .marker-positioner::after {
     position: absolute;
-    font-family: 'Material Icons Outlined';
-    content: 'report';
+    font-family: 'Material Icons';
+    content: 'error';
     font-size: 30px;
     padding: 5px;
     top: 0;

--- a/shiki-light-theme.css
+++ b/shiki-light-theme.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
-
 @font-face {
   font-family: 'FontAwesome';
   src: url('//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/fonts/fontawesome-webfont.eot?v=4.7.0');

--- a/shiki-light-theme.css
+++ b/shiki-light-theme.css
@@ -9,12 +9,7 @@
   font-weight: normal;
   font-style: normal;
 }
-@font-face {
-  font-family: 'Material Icons';
-  font-style: normal;
-  font-weight: 400;
-  src: local("Material Icons"), local("MaterialIcons-Regular"), url(https://cdnjs.cloudflare.com/ajax/libs/material-design-icons/3.0.1/iconfont/MaterialIcons-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/material-design-icons/3.0.1/iconfont/MaterialIcons-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/material-design-icons/3.0.1/iconfont/MaterialIcons-Regular.eot) format("eot"), url(https://cdnjs.cloudflare.com/ajax/libs/material-design-icons/3.0.1/iconfont/MaterialIcons-Regular.ttf) format("truetype");
-} 
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
 
 /* sticky_menu */
 @media screen and (min-width: 1025px) {

--- a/shiki-light-theme.css
+++ b/shiki-light-theme.css
@@ -12,6 +12,20 @@
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/materialicons/v143/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2) format('woff2');
+}
+
+@font-face {
+  font-family: 'Material Icons Outlined';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/materialiconsoutlined/v109/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUce.woff2) format('woff2');
+}
+
 /* sticky_menu */
 @media screen and (min-width: 1025px) {
   .l-top_menu-v2 { 
@@ -978,8 +992,8 @@ select{
 }
 .b-feedback > .marker-positioner::after {
     position: absolute;
-    font-family: 'Material Icons';
-    content: 'error';
+    font-family: 'Material Icons Outlined';
+    content: 'report';
     font-size: 30px;
     padding: 5px;
     top: 0;


### PR DESCRIPTION
The report icon was broken because shikimori beware of external sources and bloked import of your files.
Maybe it have something to do with source link and they could look suspicious and were banned by XSS injection protection or something like that.
I replaced import with content of default impot file from fonts.google.com
